### PR TITLE
fix: use new way from GitHub to set outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ runs:
         text="${text//'%'/'%25'}"
         text="${text//$'\n'/'%0A'}"
         text="${text//$'\r'/'%0D'}"
-        echo "::set-output name=value::$text"
+        echo "value=$text" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Please see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more details.

If you could apply the tag `hacktoberfest-accepted` to this PR, that would be super nice :)